### PR TITLE
React 16.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "jshashes": "^1.0.7",
-    "lodash": "^4.17.4",
     "material-ui": "^0.19.0",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/src/Upload/index.js
+++ b/src/Upload/index.js
@@ -59,7 +59,7 @@ export default class Upload extends Component {
     render() {
         return (
             <div className={styles.Container}>
-                <this.props.buttonControl {...this.getButtonProps()}>
+                <this.props.buttonControl containerElement={'label'} {...this.getButtonProps()}>
                     <input
                         className={styles.FileInput}
                         type="file"

--- a/src/Upload/index.js
+++ b/src/Upload/index.js
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 import propTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import FlatButton from 'material-ui/FlatButton';
-import {filter, assign} from 'lodash';
 
 import styles from './index.css';
 
@@ -29,10 +28,10 @@ export default class Upload extends Component {
     ];
 
     onInputChange = (e) => {
-        filter(
-            e.target.files,
-            (file) => file.type.match(this.props.fileTypeRegex) !== null
-        )
+        e.target.files
+            .filter(
+                (file) => file.type.match(this.props.fileTypeRegex) !== null
+            )
             .forEach(
                 (file) => {
                     let reader = new FileReader();
@@ -42,25 +41,7 @@ export default class Upload extends Component {
             );
     };
 
-    componentDidMount() {
-        findDOMNode(this.refs['file-input'])
-            .addEventListener(
-                'change',
-                this.onInputChange,
-                false
-            );
-    };
-
-    componentWillUnmount() {
-        findDOMNode(this.refs['file-input'])
-            .removeEventListener(
-                'change',
-                this.onInputChange,
-                false
-            );
-    };
-
-    getButtonProps() {
+    getButtonProps = () => {
         return Object
             .keys(this.props)
             .filter(
@@ -78,25 +59,14 @@ export default class Upload extends Component {
     render() {
         return (
             <div className={styles.Container}>
-              {
-                  React.createElement(
-                      this.props.buttonControl,
-                      assign(
-                          {
-                              containerElement: 'label'
-                          },
-                          this.getButtonProps()
-                      ),
-                      (
-                          <input
-                              className={styles.FileInput}
-                              type="file"
-                              ref="file-input"
-                              multiple
-                              />
-                      )
-                  )
-              }
+                <this.props.buttonControl {...this.getButtonProps()}>
+                    <input
+                        className={styles.FileInput}
+                        type="file"
+                        multiple
+                        onChange={this.onInputChange}
+                    />
+                </this.props.buttonControl>
             </div>
         );
     };


### PR DESCRIPTION
- removing unnecessary "ref" property that made this plugin incompatible with React 16.x (see issue #13 , #12 )
- getting rid of "lodash" as a dependency
